### PR TITLE
Fix comparison tree colors and clean markdown output

### DIFF
--- a/compare-users.js
+++ b/compare-users.js
@@ -218,6 +218,11 @@ function toPlain(md) {
     return String(md)
       .replace(/<a[^>]*class=\"taxon-link\"[^>]*>(.*?)<\/a>/gi, '$1')
       .replace(/<span[^>]*>.*?<\/span>/gi, '')
+      // strip custom color tokens used for markmap/text coloring
+      .replace(/\{color:[^}]+\}/gi, '')
+      .replace(/\{\/color\}/gi, '')
+      // remove picture emojis inserted for photo chips
+      .replace(/🖼️/g, '')
       .replace(/<[^>]+>/g, '')
       .replace(/\s+$/gm, '');
   } catch(_) { return md; }

--- a/index.html
+++ b/index.html
@@ -93,13 +93,13 @@
     body.dark-theme .markmap-container svg text,
     body.dark-theme .markmap-container svg tspan,
     body.dark-theme .markmap-container svg .markmap-node text { fill: #f8fafc !important; opacity: 0.96 !important; }
-    body.dark-theme .markmap-container .markmap-foreign * { color: #f8fafc !important; }
+    body.dark-theme .markmap-container .markmap-foreign *:not(.user1-node):not(.user2-node):not(.shared-node) { color: #f8fafc !important; }
 
     /* Explicit light-mode markmap text so it never ends up white on white */
     body:not(.dark-theme) .markmap-container svg text,
     body:not(.dark-theme) .markmap-container svg tspan,
     body:not(.dark-theme) .markmap-container svg .markmap-node text { fill: #111827 !important; opacity: 1 !important; }
-    body:not(.dark-theme) .markmap-container .markmap-foreign * { color: #111827 !important; }
+    body:not(.dark-theme) .markmap-container .markmap-foreign *:not(.user1-node):not(.user2-node):not(.shared-node) { color: #111827 !important; }
 
     /* Default link strokes */
     .markmap-container svg path { stroke: #9aa1a7; }                 /* light */

--- a/script.js
+++ b/script.js
@@ -48,6 +48,11 @@ function toPlain(md) {
     return String(md)
       .replace(/<a[^>]*class=\"taxon-link\"[^>]*>(.*?)<\/a>/gi, '$1')
       .replace(/<span[^>]*>.*?<\/span>/gi, '')
+      // strip custom color tokens used for markmap/text coloring
+      .replace(/\{color:[^}]+\}/gi, '')
+      .replace(/\{\/color\}/gi, '')
+      // remove picture emojis inserted for photo chips
+      .replace(/🖼️/g, '')
       .replace(/<[^>]+>/g, '')
       .replace(/\s+$/gm, '');
   } catch (_) { return md; }

--- a/worker.js
+++ b/worker.js
@@ -817,6 +817,8 @@ function toPlainMarkdown(md) {
     // strip custom color tokens used for markmap/text coloring
     .replace(/\{color:[^}]+\}/gi, '')
     .replace(/\{\/color\}/gi, '')
+    // remove picture emojis inserted for photo chips
+    .replace(/🖼️/g, '')
     .replace(/<[^>]+>/g, '')
     .replace(/\s+$/gm, '');
 }


### PR DESCRIPTION
## Summary
- Ensure markmap comparison trees keep user-specific label colors in both light and dark themes
- Strip color tokens and photo emoji from generated markdown to keep "Show Generated Markdown" clean

## Testing
- `node - <<'NODE'
function toPlainMarkdown(md){
  return String(md)
    .replace(/<a[^>]*class="taxon-link"[^>]*>(.*?)<\/a>/gi, '$1')
    .replace(/<span[^>]*>.*?<\/span>/gi, '')
    .replace(/\{color:[^}]+\}/gi, '')
    .replace(/\{\/color\}/gi, '')
    .replace(/🖼️/g, '')
    .replace(/<[^>]+>/g, '')
    .replace(/\s+$/gm, '');
}
const md = '- {color:red}<a class="taxon-link" href="#">Oak</a> <span class="mm-badge">x</span> 🖼️{/color}\n';
console.log(toPlainMarkdown(md));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68b099e39298832391ea96706807d6dd