### PR TITLE
Color comparison markmap branches and clean markdown

### DIFF
--- a/compare-users.js
+++ b/compare-users.js
@@ -201,8 +201,8 @@ document.addEventListener('DOMContentLoaded', function() {
           showError("No observations found for at least one of the users under the selected taxon.");
           return;
         }
-        window.lastComparePlainMarkdown = result.plainMarkdown;
-        renderComparison(markdown, username1, username2, taxonName, taxonId);
+        window.lastComparePlainMarkdown = plainMarkdown;
+        renderComparison(markdown, username1, username2, taxonName, taxonId, plainMarkdown);
       } catch (err) {
         clearInterval(messageInterval);
         hideCompareLoadingSpinner();
@@ -218,13 +218,17 @@ function toPlain(md) {
     return String(md)
       .replace(/<a[^>]*class=\"taxon-link\"[^>]*>(.*?)<\/a>/gi, '$1')
       .replace(/<span[^>]*>.*?<\/span>/gi, '')
+      // remove custom color tokens and picture emojis
+      .replace(/\{color:[^}]+\}/gi, '')
+      .replace(/\{\/color\}/gi, '')
+      .replace(/🖼️/g, '')
       .replace(/<[^>]+>/g, '')
       .replace(/\s+$/gm, '');
   } catch(_) { return md; }
 }
 
 function renderComparison(markdown, username1, username2, taxonName, taxonId, plainMarkdown) {
-  document.getElementById("markdownResult").textContent = (window.lastComparePlainMarkdown || markdown);
+  document.getElementById("markdownResult").textContent = plainMarkdown || window.lastComparePlainMarkdown || toPlain(markdown);
 
   // Calculate statistics before adding the tree
   let stats = null;

--- a/markmap-integration.js
+++ b/markmap-integration.js
@@ -2,15 +2,21 @@
 document.addEventListener('DOMContentLoaded', function() {
   const style = document.createElement('style');
   style.textContent = `
-    .user1-node {
+    .user1-node,
+    .user1-node a,
+    .user1-node .mm-common {
       color: #ff6b6b !important;
       font-weight: bold !important;
     }
-    .user2-node {
+    .user2-node,
+    .user2-node a,
+    .user2-node .mm-common {
       color: #4dabf7 !important;
       font-weight: bold !important;
     }
-    .shared-node {
+    .shared-node,
+    .shared-node a,
+    .shared-node .mm-common {
       color: #cc5de8 !important;
       font-weight: bold !important;
     }

--- a/script.js
+++ b/script.js
@@ -48,6 +48,10 @@ function toPlain(md) {
     return String(md)
       .replace(/<a[^>]*class=\"taxon-link\"[^>]*>(.*?)<\/a>/gi, '$1')
       .replace(/<span[^>]*>.*?<\/span>/gi, '')
+      // strip custom color tokens and picture emojis
+      .replace(/\{color:[^}]+\}/gi, '')
+      .replace(/\{\/color\}/gi, '')
+      .replace(/🖼️/g, '')
       .replace(/<[^>]+>/g, '')
       .replace(/\s+$/gm, '');
   } catch (_) { return md; }

--- a/worker.js
+++ b/worker.js
@@ -817,6 +817,8 @@ function toPlainMarkdown(md) {
     // strip custom color tokens used for markmap/text coloring
     .replace(/\{color:[^}]+\}/gi, '')
     .replace(/\{\/color\}/gi, '')
+    // remove any picture emoji chips
+    .replace(/🖼️/g, '')
     .replace(/<[^>]+>/g, '')
     .replace(/\s+$/gm, '');
 }
@@ -1028,6 +1030,24 @@ function generateComparisonStats(user1TaxonIds, user2TaxonIds) {
   return { user1Total: user1TaxonIds.length, user2Total: user2TaxonIds.length, user1Only, user2Only, shared };
 }
 
+// Ensure ancestors adopt the color of their descendants unless there is a mix
+function propagateBranchColors(node) {
+  if (!node || !node.children || Object.keys(node.children).length === 0) {
+    return node?.color;
+  }
+  const childColors = new Set();
+  for (const child of Object.values(node.children)) {
+    const c = propagateBranchColors(child);
+    if (c) childColors.add(c);
+  }
+  if (childColors.size === 1) {
+    node.color = childColors.values().next().value;
+  } else if (childColors.size > 1) {
+    node.color = SHARED_COLOR;
+  }
+  return node.color;
+}
+
 async function buildComparisonTree(env, user1TaxonIds, user2TaxonIds, baseTaxonId) {
   const user1Set = new Set(user1TaxonIds);
   const user2Set = new Set(user2TaxonIds);
@@ -1105,6 +1125,7 @@ async function buildComparisonTree(env, user1TaxonIds, user2TaxonIds, baseTaxonI
     }
     added.add(taxonId);
   }
+  propagateBranchColors(root);
   return root;
 }
 


### PR DESCRIPTION
## Summary
- ensure comparison tree labels and branches reflect user ownership
- strip color tokens and photo emojis from generated markdown
- color entire branches via recursive propagation

## Testing
- `node --check compare-users.js script.js markmap-integration.js worker.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b099e39298832391ea96706807d6dd