### PR TITLE
Color comparison markmap branches

### DIFF
--- a/markmap-integration.js
+++ b/markmap-integration.js
@@ -1,32 +1,48 @@
 // markmap-integration.js
 document.addEventListener('DOMContentLoaded', function() {
   const style = document.createElement('style');
-  style.textContent = `
-    .user1-node {
-      color: #ff6b6b !important;
-      font-weight: bold !important;
-    }
-    .user2-node {
-      color: #4dabf7 !important;
-      font-weight: bold !important;
-    }
-    .shared-node {
-      color: #cc5de8 !important;
-      font-weight: bold !important;
-    }
-    .battle-summary {
-      margin-top: 20px;
-      border-radius: 8px;
-      overflow: hidden;
-    }
-    .vs-badge {
-      background-color: #f8f9fa;
-      color: #495057;
-      padding: 3px 8px;
-      border-radius: 4px;
-      font-weight: bold;
-    }
-  `;
+    style.textContent = `
+      :root {
+        --user1-color: #ff6b6b;
+        --user2-color: #4dabf7;
+        --shared-color: #cc5de8;
+      }
+      body.dark-theme {
+        --user1-color: #ff8787;
+        --user2-color: #74c0fc;
+        --shared-color: #da77f2;
+      }
+      .user1-node {
+        color: var(--user1-color) !important;
+        font-weight: bold !important;
+      }
+      .user2-node {
+        color: var(--user2-color) !important;
+        font-weight: bold !important;
+      }
+      .shared-node {
+        color: var(--shared-color) !important;
+        font-weight: bold !important;
+      }
+      path.user1-edge { stroke: var(--user1-color); }
+      path.user2-edge { stroke: var(--user2-color); }
+      path.shared-edge { stroke: var(--shared-color); }
+      g.user1-edge > circle { fill: var(--user1-color); stroke: var(--user1-color); }
+      g.user2-edge > circle { fill: var(--user2-color); stroke: var(--user2-color); }
+      g.shared-edge > circle { fill: var(--shared-color); stroke: var(--shared-color); }
+      .battle-summary {
+        margin-top: 20px;
+        border-radius: 8px;
+        overflow: hidden;
+      }
+      .vs-badge {
+        background-color: #f8f9fa;
+        color: #495057;
+        padding: 3px 8px;
+        border-radius: 4px;
+        font-weight: bold;
+      }
+    `;
   document.head.appendChild(style);
 });
 

--- a/tree-manager.js
+++ b/tree-manager.js
@@ -361,25 +361,33 @@ class TreeManager {
     // Paint incoming edges based on which colored span is present in the label
     const paint = () => {
       const nodes = svg.querySelectorAll('g.markmap-node');
-      nodes.forEach(node => {
-        const has1 = !!node.querySelector('.user1-node');
-        const has2 = !!node.querySelector('.user2-node');
-        const hasS = !!node.querySelector('.shared-node');
+        nodes.forEach(node => {
+          const has1 = !!node.querySelector('.user1-node');
+          const has2 = !!node.querySelector('.user2-node');
+          const hasS = !!node.querySelector('.shared-node');
 
-        // Find the incoming edge for this node
-        let edge = node.previousElementSibling;
-        if (!edge || String(edge.tagName).toLowerCase() !== 'path') {
-          // Fallback: some markmap versions nest the path inside
-          edge = node.querySelector('path');
-        }
-        if (!edge) return;
+          // Find the incoming edge for this node
+          let edge = node.previousElementSibling;
+          if (!edge || String(edge.tagName).toLowerCase() !== 'path') {
+            // Fallback: some markmap versions nest the path inside
+            edge = node.querySelector('path');
+          }
 
-        edge.classList.remove('user1-edge', 'user2-edge', 'shared-edge');
-        if (hasS || (has1 && has2)) edge.classList.add('shared-edge');
-        else if (has1) edge.classList.add('user1-edge');
-        else if (has2) edge.classList.add('user2-edge');
-      });
-    };
+          node.classList.remove('user1-edge', 'user2-edge', 'shared-edge');
+          if (edge) edge.classList.remove('user1-edge', 'user2-edge', 'shared-edge');
+
+          if (hasS || (has1 && has2)) {
+            if (edge) edge.classList.add('shared-edge');
+            node.classList.add('shared-edge');
+          } else if (has1) {
+            if (edge) edge.classList.add('user1-edge');
+            node.classList.add('user1-edge');
+          } else if (has2) {
+            if (edge) edge.classList.add('user2-edge');
+            node.classList.add('user2-edge');
+          }
+        });
+      };
 
     // Initial pass, then keep repainting on expand/collapse
     setTimeout(paint, 0);

--- a/worker.js
+++ b/worker.js
@@ -813,11 +813,13 @@ async function firstObservation(request, env) {
 function toPlainMarkdown(md) {
   return String(md)
     .replace(/<a[^>]*class=\"taxon-link\"[^>]*>(.*?)<\/a>/gi, '$1')
+    .replace(/<a[^>]*class=\"mm-badge mm-photo[^>]*>.*?<\/a>/gi, '')
     .replace(/<span[^>]*>.*?<\/span>/gi, '')
     // strip custom color tokens used for markmap/text coloring
     .replace(/\{color:[^}]+\}/gi, '')
     .replace(/\{\/color\}/gi, '')
     .replace(/<[^>]+>/g, '')
+    .replace(/🖼️/g, '')
     .replace(/\s+$/gm, '');
 }
 // POST /timeline/precache { username, taxonId, checkpointId }


### PR DESCRIPTION
## Summary
- theme-aware colors for comparison markmap nodes and edges
- propagate edge classes so entire branches show user1/user2/shared colors
- strip custom color tags and photo emojis from generated Markdown

## Testing
- `node --check markmap-integration.js`
- `node --check tree-manager.js`
- `node --check worker.js`
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b099e39298832391ea96706807d6dd