### PR TITLE
Color comparison tree branches and clean markdown

### DIFF
--- a/compare-users.js
+++ b/compare-users.js
@@ -196,13 +196,13 @@ document.addEventListener('DOMContentLoaded', function() {
           return;
         }
         const markdown = result.markdown;
-        const plainMarkdown = result.plainMarkdown;
+        const plainMarkdown = result.plainMarkdown || toPlain(markdown);
         if (!markdown || markdown.trim() === "" || markdown.includes("No observations found")) {
           showError("No observations found for at least one of the users under the selected taxon.");
           return;
         }
-        window.lastComparePlainMarkdown = result.plainMarkdown;
-        renderComparison(markdown, username1, username2, taxonName, taxonId);
+        window.lastComparePlainMarkdown = plainMarkdown;
+        renderComparison(markdown, username1, username2, taxonName, taxonId, plainMarkdown);
       } catch (err) {
         clearInterval(messageInterval);
         hideCompareLoadingSpinner();
@@ -218,13 +218,17 @@ function toPlain(md) {
     return String(md)
       .replace(/<a[^>]*class=\"taxon-link\"[^>]*>(.*?)<\/a>/gi, '$1')
       .replace(/<span[^>]*>.*?<\/span>/gi, '')
+      // remove custom color tokens and picture emojis
+      .replace(/\{color:[^}]+\}/gi, '')
+      .replace(/\{\/color\}/gi, '')
+      .replace(/🖼️/g, '')
       .replace(/<[^>]+>/g, '')
       .replace(/\s+$/gm, '');
   } catch(_) { return md; }
 }
 
 function renderComparison(markdown, username1, username2, taxonName, taxonId, plainMarkdown) {
-  document.getElementById("markdownResult").textContent = (window.lastComparePlainMarkdown || markdown);
+  document.getElementById("markdownResult").textContent = plainMarkdown || window.lastComparePlainMarkdown || toPlain(markdown);
 
   // Calculate statistics before adding the tree
   let stats = null;

--- a/markmap-integration.js
+++ b/markmap-integration.js
@@ -2,18 +2,36 @@
 document.addEventListener('DOMContentLoaded', function() {
   const style = document.createElement('style');
   style.textContent = `
+    :root {
+      --user1-color: #ff6b6b;
+      --user2-color: #4dabf7;
+      --shared-color: #cc5de8;
+    }
+    body.dark-theme {
+      --user1-color: #ff8787;
+      --user2-color: #74c0fc;
+      --shared-color: #da77f2;
+    }
     .user1-node {
-      color: #ff6b6b !important;
+      color: var(--user1-color) !important;
       font-weight: bold !important;
     }
     .user2-node {
-      color: #4dabf7 !important;
+      color: var(--user2-color) !important;
       font-weight: bold !important;
     }
     .shared-node {
-      color: #cc5de8 !important;
+      color: var(--shared-color) !important;
       font-weight: bold !important;
     }
+    path.user1-edge { stroke: var(--user1-color); }
+    path.user2-edge { stroke: var(--user2-color); }
+    path.shared-edge { stroke: var(--shared-color); }
+    g.user1-edge > circle { fill: var(--user1-color); stroke: var(--user1-color); }
+    g.user2-edge > circle { fill: var(--user2-color); stroke: var(--user2-color); }
+    g.shared-edge > circle { fill: var(--shared-color); stroke: var(--shared-color); }
+    body.dark-theme svg.markmap text { fill: #f8fafc; opacity: 0.96; }
+    body.dark-theme .markmap-foreign * { color: #f8fafc; }
     .battle-summary {
       margin-top: 20px;
       border-radius: 8px;

--- a/tree-manager.js
+++ b/tree-manager.js
@@ -165,18 +165,6 @@ class TreeManager {
     const transformer = new Transformer();
     const { root } = transformer.transform(tree.markdown);
     const mm = Markmap.create(svg, { htmlLabels: true }, root);
-    try {
-      // ensure labels are bright in dark theme (html labels too)
-      const isDark = document.body.classList.contains('dark-theme');
-      if (isDark) {
-        setTimeout(() => {
-          const texts = svg.querySelectorAll('text, tspan, .markmap-node text');
-          texts.forEach(t => { t.setAttribute('fill', '#f8fafc'); t.style.opacity = '0.96'; });
-          const foreign = svg.querySelectorAll('.markmap-foreign *');
-          foreign.forEach(el => { el.style.color = '#f8fafc'; });
-        }, 0);
-      }
-    } catch (_) {}
 
     // Add statistics dashboard if available
     try {
@@ -373,11 +361,18 @@ class TreeManager {
           edge = node.querySelector('path');
         }
         if (!edge) return;
-
         edge.classList.remove('user1-edge', 'user2-edge', 'shared-edge');
-        if (hasS || (has1 && has2)) edge.classList.add('shared-edge');
-        else if (has1) edge.classList.add('user1-edge');
-        else if (has2) edge.classList.add('user2-edge');
+        node.classList.remove('user1-edge', 'user2-edge', 'shared-edge');
+        if (hasS || (has1 && has2)) {
+          edge.classList.add('shared-edge');
+          node.classList.add('shared-edge');
+        } else if (has1) {
+          edge.classList.add('user1-edge');
+          node.classList.add('user1-edge');
+        } else if (has2) {
+          edge.classList.add('user2-edge');
+          node.classList.add('user2-edge');
+        }
       });
     };
 
@@ -402,16 +397,6 @@ class TreeManager {
         console.log("Clicked node:", node);
       }
     }, root);
-    try {
-      if (document.body.classList.contains('dark-theme')) {
-        setTimeout(() => {
-          const texts = svg.querySelectorAll('text, tspan, .markmap-node text');
-          texts.forEach(t => { t.setAttribute('fill', '#f8fafc'); t.style.opacity = '0.96'; });
-          const foreign = svg.querySelectorAll('.markmap-foreign *');
-          foreign.forEach(el => { el.style.color = '#f8fafc'; });
-        }, 0);
-      }
-    } catch (_) {}
     this.setupComparisonTreeRendering(svg);
 
     // Remove any existing statistics elements to prevent duplicates

--- a/worker.js
+++ b/worker.js
@@ -817,6 +817,8 @@ function toPlainMarkdown(md) {
     // strip custom color tokens used for markmap/text coloring
     .replace(/\{color:[^}]+\}/gi, '')
     .replace(/\{\/color\}/gi, '')
+    // remove photo emoji markers
+    .replace(/🖼️/g, '')
     .replace(/<[^>]+>/g, '')
     .replace(/\s+$/gm, '');
 }


### PR DESCRIPTION
## Summary
- Color comparison tree labels and branches for each user and shared taxa, with dark and light theme palettes
- Remove color tags and photo emoji from generated markdown
- Apply edge and node classes for branch coloring and rely on CSS for dark-theme text styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a22f716c8323bda2a248984bf076