### PR TITLE
Color comparison branches and sanitize markdown

### DIFF
--- a/checkpoint-ui.js
+++ b/checkpoint-ui.js
@@ -375,7 +375,14 @@ async function drawTreeAtDate(isoDate) {
   if (!r.ok || !data?.markdown) { console.error('tree-at-date error', data); return; }
   const pre = document.getElementById('cpMarkdownResult');
   try {
-    const plain = data.plainMarkdown || String(data.markdown).replace(/<a[^>]*class=\"taxon-link\"[^>]*>(.*?)<\/a>/gi,'$1').replace(/<span[^>]*>.*?<\/span>/gi,'').replace(/<[^>]+>/g,'').replace(/\s+$/gm,'');
+    const plain = data.plainMarkdown || String(data.markdown)
+      .replace(/<a[^>]*class=\"taxon-link\"[^>]*>(.*?)<\/a>/gi,'$1')
+      .replace(/<span[^>]*>.*?<\/span>/gi,'')
+      .replace(/\{color:[^}]+\}/gi,'')
+      .replace(/\{\/color\}/gi,'')
+      .replace(/🖼️/g,'')
+      .replace(/<[^>]+>/g,'')
+      .replace(/\s+$/gm,'');
     if (pre) pre.textContent = plain;
   } catch(_) { if (pre) pre.textContent = data.markdown; }
   const tabId = currentCpTabId || `cp-live-${currentTaxonId}`;
@@ -463,7 +470,14 @@ async function renderCheckpointTree(group, idx) {
     renderMarkdownToTab(tabId, markdown);
     const pre = document.getElementById('cpMarkdownResult');
     try {
-      const plain = data.plainMarkdown || String(markdown).replace(/<a[^>]*class=\"taxon-link\"[^>]*>(.*?)<\/a>/gi,'$1').replace(/<span[^>]*>.*?<\/span>/gi,'').replace(/<[^>]+>/g,'').replace(/\s+$/gm,'');
+      const plain = data.plainMarkdown || String(markdown)
+        .replace(/<a[^>]*class=\"taxon-link\"[^>]*>(.*?)<\/a>/gi,'$1')
+        .replace(/<span[^>]*>.*?<\/span>/gi,'')
+        .replace(/\{color:[^}]+\}/gi,'')
+        .replace(/\{\/color\}/gi,'')
+        .replace(/🖼️/g,'')
+        .replace(/<[^>]+>/g,'')
+        .replace(/\s+$/gm,'');
       if (pre) pre.textContent = plain;
     } catch(_) { if (pre) pre.textContent = markdown; }
     cpCacheSet(cachedKey, markdown);

--- a/compare-users.js
+++ b/compare-users.js
@@ -201,8 +201,8 @@ document.addEventListener('DOMContentLoaded', function() {
           showError("No observations found for at least one of the users under the selected taxon.");
           return;
         }
-        window.lastComparePlainMarkdown = result.plainMarkdown;
-        renderComparison(markdown, username1, username2, taxonName, taxonId);
+        window.lastComparePlainMarkdown = plainMarkdown;
+        renderComparison(markdown, username1, username2, taxonName, taxonId, plainMarkdown);
       } catch (err) {
         clearInterval(messageInterval);
         hideCompareLoadingSpinner();
@@ -218,13 +218,18 @@ function toPlain(md) {
     return String(md)
       .replace(/<a[^>]*class=\"taxon-link\"[^>]*>(.*?)<\/a>/gi, '$1')
       .replace(/<span[^>]*>.*?<\/span>/gi, '')
+      // strip custom color tokens used for markmap/text coloring
+      .replace(/\{color:[^}]+\}/gi, '')
+      .replace(/\{\/color\}/gi, '')
+      // remove picture emojis inserted for photo chips
+      .replace(/🖼️/g, '')
       .replace(/<[^>]+>/g, '')
       .replace(/\s+$/gm, '');
   } catch(_) { return md; }
 }
 
 function renderComparison(markdown, username1, username2, taxonName, taxonId, plainMarkdown) {
-  document.getElementById("markdownResult").textContent = (window.lastComparePlainMarkdown || markdown);
+  document.getElementById("markdownResult").textContent = plainMarkdown || window.lastComparePlainMarkdown || toPlain(markdown);
 
   // Calculate statistics before adding the tree
   let stats = null;

--- a/index.html
+++ b/index.html
@@ -105,16 +105,6 @@
     .markmap-container svg path { stroke: #9aa1a7; }                 /* light */
     body.dark-theme .markmap-container svg path { stroke: #6f918a; } /* dark */
 
-    /* PVP edges (win in both themes) */
-    .markmap-container svg path.user1-edge { stroke: #ff6b6b !important; }
-    .markmap-container svg path.user2-edge { stroke: #4dabf7 !important; }
-    .markmap-container svg path.shared-edge { stroke: #cc5de8 !important; }
-
-    /* PVP label colors (apply to spans, anchors, and any descendants) */
-    .user1-node, .user1-node a, .user1-node * { color: #ff6b6b !important; }
-    .user2-node, .user2-node a, .user2-node * { color: #4dabf7 !important; }
-    .shared-node, .shared-node a, .shared-node * { color: #cc5de8 !important; }
-
     .navbar {
       background-color: var(--primary-color);
     }

--- a/markmap-integration.js
+++ b/markmap-integration.js
@@ -2,31 +2,47 @@
 document.addEventListener('DOMContentLoaded', function() {
   const style = document.createElement('style');
   style.textContent = `
-    .user1-node {
-      color: #ff6b6b !important;
-      font-weight: bold !important;
-    }
-    .user2-node {
-      color: #4dabf7 !important;
-      font-weight: bold !important;
-    }
-    .shared-node {
-      color: #cc5de8 !important;
-      font-weight: bold !important;
-    }
-    .battle-summary {
-      margin-top: 20px;
-      border-radius: 8px;
-      overflow: hidden;
-    }
-    .vs-badge {
-      background-color: #f8f9fa;
-      color: #495057;
-      padding: 3px 8px;
-      border-radius: 4px;
-      font-weight: bold;
-    }
-  `;
+      :root {
+        --user1-color: #ff6b6b;
+        --user2-color: #4dabf7;
+        --shared-color: #cc5de8;
+      }
+      body.dark-theme {
+        --user1-color: #ff8787;
+        --user2-color: #74c0fc;
+        --shared-color: #da77f2;
+      }
+      .user1-node {
+        color: var(--user1-color) !important;
+        font-weight: bold !important;
+      }
+      .user2-node {
+        color: var(--user2-color) !important;
+        font-weight: bold !important;
+      }
+      .shared-node {
+        color: var(--shared-color) !important;
+        font-weight: bold !important;
+      }
+      .markmap-container svg path.user1-edge { stroke: var(--user1-color); }
+      .markmap-container svg path.user2-edge { stroke: var(--user2-color); }
+      .markmap-container svg path.shared-edge { stroke: var(--shared-color); }
+      .markmap-container svg g.user1-edge > circle { fill: var(--user1-color); stroke: var(--user1-color); }
+      .markmap-container svg g.user2-edge > circle { fill: var(--user2-color); stroke: var(--user2-color); }
+      .markmap-container svg g.shared-edge > circle { fill: var(--shared-color); stroke: var(--shared-color); }
+      .battle-summary {
+        margin-top: 20px;
+        border-radius: 8px;
+        overflow: hidden;
+      }
+      .vs-badge {
+        background-color: #f8f9fa;
+        color: #495057;
+        padding: 3px 8px;
+        border-radius: 4px;
+        font-weight: bold;
+      }
+    `;
   document.head.appendChild(style);
 });
 

--- a/script.js
+++ b/script.js
@@ -48,6 +48,11 @@ function toPlain(md) {
     return String(md)
       .replace(/<a[^>]*class=\"taxon-link\"[^>]*>(.*?)<\/a>/gi, '$1')
       .replace(/<span[^>]*>.*?<\/span>/gi, '')
+      // strip custom color tokens used for markmap/text coloring
+      .replace(/\{color:[^}]+\}/gi, '')
+      .replace(/\{\/color\}/gi, '')
+      // remove picture emojis inserted for photo chips
+      .replace(/🖼️/g, '')
       .replace(/<[^>]+>/g, '')
       .replace(/\s+$/gm, '');
   } catch (_) { return md; }

--- a/tree-manager.js
+++ b/tree-manager.js
@@ -375,9 +375,17 @@ class TreeManager {
         if (!edge) return;
 
         edge.classList.remove('user1-edge', 'user2-edge', 'shared-edge');
-        if (hasS || (has1 && has2)) edge.classList.add('shared-edge');
-        else if (has1) edge.classList.add('user1-edge');
-        else if (has2) edge.classList.add('user2-edge');
+        node.classList.remove('user1-edge', 'user2-edge', 'shared-edge');
+        if (hasS || (has1 && has2)) {
+          edge.classList.add('shared-edge');
+          node.classList.add('shared-edge');
+        } else if (has1) {
+          edge.classList.add('user1-edge');
+          node.classList.add('user1-edge');
+        } else if (has2) {
+          edge.classList.add('user2-edge');
+          node.classList.add('user2-edge');
+        }
       });
     };
 

--- a/worker.js
+++ b/worker.js
@@ -817,6 +817,7 @@ function toPlainMarkdown(md) {
     // strip custom color tokens used for markmap/text coloring
     .replace(/\{color:[^}]+\}/gi, '')
     .replace(/\{\/color\}/gi, '')
+    .replace(/🖼️/g, '')
     .replace(/<[^>]+>/g, '')
     .replace(/\s+$/gm, '');
 }


### PR DESCRIPTION
## Summary
- Color comparison markmap branches using theme-aware CSS variables and apply colors to edges and node markers
- Tag comparison tree nodes and edges for branch coloring
- Strip custom color tags and photo emojis from generated markdown

## Testing
- `node --check markmap-integration.js`
- `node --check tree-manager.js`
- `node --check compare-users.js`
- `node --check script.js`
- `node --check worker.js`
- `node --check checkpoint-ui.js`


------
https://chatgpt.com/codex/tasks/task_e_68b0a22f716c8323bda2a248984bf076